### PR TITLE
Update Tokenizer to treat Markdown code as text instead of HTML

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -7,6 +7,7 @@ var decodeCodePoint = require("entities/lib/decode_codepoint.js"),
 
     i = 0,
 
+    MARKDOWN                  = i++,
     TEXT                      = i++,
     BEFORE_TAG_NAME           = i++, //after <
     IN_TAG_NAME               = i++,
@@ -144,17 +145,26 @@ function Tokenizer(options, cbs){
 	this._ended = false;
 	this._xmlMode = !!(options && options.xmlMode);
 	this._decodeEntities = !!(options && options.decodeEntities);
-	this._isMarkdownCode = false;
+}
+
+Tokenizer.prototype._stateMarkdown = function(c){
+	if(c === '`') {
+		this._state = TEXT;
+	}
 }
 
 Tokenizer.prototype._stateText = function(c){
-	// Parse open tag if it is not Markdown
-	if(c === "<" && !this._isMarkdownCode){
-		if(this._index > this._sectionStart){
-			this._cbs.ontext(this._getSection());
+	if(c === '`'){
+		this._state = MARKDOWN;
+	} else if(c === "<"){
+		var isInequality = (this._index + 1 < this._buffer.length) && (this._buffer.charAt(this._index + 1) === '=');
+		if(!isInequality){
+			if(this._index > this._sectionStart){
+				this._cbs.ontext(this._getSection());
+			}
+			this._state = BEFORE_TAG_NAME;
+			this._sectionStart = this._index;
 		}
-		this._state = BEFORE_TAG_NAME;
-		this._sectionStart = this._index;
 	} else if(this._decodeEntities && this._special === SPECIAL_NONE && c === "&"){
 		if(this._index > this._sectionStart){
 			this._cbs.ontext(this._getSection());
@@ -637,15 +647,14 @@ Tokenizer.prototype.write = function(chunk){
 Tokenizer.prototype._parse = function(){
 	while(this._index < this._buffer.length && this._running){
 		var c = this._buffer.charAt(this._index);
-		// Detect Markdown code so that it is parsed as text instead of HTML
-		if(c === '`'){
-			this._isMarkdownCode = !this._isMarkdownCode;
-		}
-		if(this._state === TEXT) {
+
+		if(this._state === MARKDOWN){
+			this._stateMarkdown(c);
+		} else if(this._state === TEXT){
 			this._stateText(c);
 		} else if(this._state === BEFORE_TAG_NAME){
 			this._stateBeforeTagName(c);
-		} else if(this._state === IN_TAG_NAME) {
+		} else if(this._state === IN_TAG_NAME){
 			this._stateInTagName(c);
 		} else if(this._state === BEFORE_CLOSING_TAG_NAME){
 			this._stateBeforeCloseingTagName(c);

--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -144,10 +144,12 @@ function Tokenizer(options, cbs){
 	this._ended = false;
 	this._xmlMode = !!(options && options.xmlMode);
 	this._decodeEntities = !!(options && options.decodeEntities);
+	this._isMarkdownCode = false;
 }
 
 Tokenizer.prototype._stateText = function(c){
-	if(c === "<"){
+	// Parse open tag if it is not Markdown
+	if(c === "<" && !this._isMarkdownCode){
 		if(this._index > this._sectionStart){
 			this._cbs.ontext(this._getSection());
 		}
@@ -635,6 +637,10 @@ Tokenizer.prototype.write = function(chunk){
 Tokenizer.prototype._parse = function(){
 	while(this._index < this._buffer.length && this._running){
 		var c = this._buffer.charAt(this._index);
+		// Detect Markdown code so that it is parsed as text instead of HTML
+		if(c === '`'){
+			this._isMarkdownCode = !this._isMarkdownCode;
+		}
 		if(this._state === TEXT) {
 			this._stateText(c);
 		} else if(this._state === BEFORE_TAG_NAME){


### PR DESCRIPTION
This fix allows Markdown code to contain '<' , '<=' without having it affect other HTML elements as it is now treated as a text element. Furthermore, no spaces are required when typing these symbols within the back ticks. 

 As such, inequalities like the above can be rendered normally as shown below.

![image](https://user-images.githubusercontent.com/251231/35399387-0d148d5e-022f-11e8-89f1-16a3ed2107e8.png)

Resolves https://github.com/MarkBind/markbind/issues/101


