### PR TITLE
Add UML parsing state to prevent UML code being parse as HTML

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -7,6 +7,7 @@ var decodeCodePoint = require("entities/lib/decode_codepoint.js"),
 
     i = 0,
 
+    UML                       = i++,
     MARKDOWN                  = i++,
     TEXT                      = i++,
     BEFORE_TAG_NAME           = i++, //after <
@@ -153,10 +154,20 @@ Tokenizer.prototype._stateMarkdown = function(c){
 	}
 }
 
+Tokenizer.prototype._stateUml = function(c){
+	if(c === "@" && this._buffer.slice(this._index, this._index + 4) === "@end") {
+		this._state = TEXT;
+	}
+}
+
 Tokenizer.prototype._stateText = function(c){
 	if(c === '`'){
 		this._state = MARKDOWN;
-	} else if(c === "<"){
+	} else if(c === "@") {
+		if(this._buffer.slice(this._index, this._index + 6) === "@start") {
+			this._state = UML;
+		}
+	} else if(c === "<") {
 		var isInequality = (this._index + 1 < this._buffer.length) && (this._buffer.charAt(this._index + 1) === '=');
 		if(!isInequality){
 			if(this._index > this._sectionStart){
@@ -650,6 +661,8 @@ Tokenizer.prototype._parse = function(){
 
 		if(this._state === MARKDOWN){
 			this._stateMarkdown(c);
+		} else if(this._state === UML){
+			this._stateUml(c);
 		} else if(this._state === TEXT){
 			this._stateText(c);
 		} else if(this._state === BEFORE_TAG_NAME){


### PR DESCRIPTION
Currently, certain symbols within PlantUML's syntax such as `<|--` are being parsed as HTML. This causes additional characters to be added which interferes with diagram generation.

This commit adds a new parsing state for UML, entered with `@startuml` 